### PR TITLE
Allows Syndicate crew to use guns that have a Syndicate firing pin

### DIFF
--- a/nsv13/code/game/gamemodes/pvp/roles.dm
+++ b/nsv13/code/game/gamemodes/pvp/roles.dm
@@ -174,6 +174,7 @@ Singleton to handle conquest roles. This exists to populate the roles list and n
 /datum/outfit/syndicate/no_crystals/syndi_crew/post_equip(mob/living/carbon/human/H)
 	H.faction += "Syndicate"
 	var/obj/item/card/id/W = H.wear_id
+	implants = list(/obj/item/implant/weapons_auth)
 	W.registered_name = H.real_name
 	W.update_label()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes [#1739](https://github.com/BeeStation/NSV13/issues/1739)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Gives all syndicate crew weapon authentication implants, allowing them to fire weapons that have a syndicate firing pin
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Syndicate crew can now fire guns that have a syndicate firing pin
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
